### PR TITLE
Allow creation of errors with causes via err_msg_with and bail_with

### DIFF
--- a/examples/bail_ensure.rs
+++ b/examples/bail_ensure.rs
@@ -1,11 +1,26 @@
 #[macro_use]
 extern crate failure;
 
+use std::fmt::{self, Display, Formatter};
 use failure::Error;
 
+#[derive(Debug, Fail)]
+struct ExampleFail {
+    num: u8
+}
+
+impl Display for ExampleFail {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self.num, f)
+    }
+}
+
 fn bailer() -> Result<(), Error> {
-    // bail!("ruh roh");
     bail!("ruh {}", "roh");
+}
+
+fn bailer_cause() -> Result<(), Error> {
+    bail_with!(ExampleFail{ num: 42 }, "ruh {}", "roh");
 }
 
 fn ensures() -> Result<(), Error> {
@@ -18,6 +33,10 @@ fn main() {
     match bailer() {
         Ok(_) => println!("ok"),
         Err(e) => println!("{}", e),
+    }
+    match bailer_cause() {
+        Ok(_) => println!("ok"),
+        Err(e) => println!("{} cause: {}", e, e.find_root_cause())
     }
     match ensures() {
         Ok(_) => println!("ok"),

--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -9,17 +9,38 @@ use Error;
 /// can be passed around, if you do not want to create a new `Fail` type for
 /// this use case.
 pub fn err_msg<D: Display + Debug + Sync + Send + 'static>(msg: D) -> Error {
-    Error::from(ErrorMessage { msg })
+    Error::from(ErrorMessage { msg, cause: None })
 }
 
-/// A `Fail` type that just contains an error message. You can construct
-/// this from the `err_msg` function.
+/// Constructs a `Fail` type from a string and `Fail` as the cause.
+///
+/// This is a convenient way to turn a string into an error value that
+/// can be passed around, if you do not want to create a new `Fail` type for
+/// this use case.
+pub fn err_msg_with<C, D>(cause: C, msg: D) -> Error
+where
+	C: Fail,
+	D: Display + Debug + Sync + Send + 'static,
+{
+    Error::from(ErrorMessage { msg, cause: Some(Box::new(cause)) })
+}
+
+/// A `Fail` type that just contains an error message and optional cause.
+/// You can construct this with the `err_msg` and `err_msg_cause` functions.
 #[derive(Debug)]
 struct ErrorMessage<D: Display + Debug + Sync + Send + 'static> {
     msg: D,
+    cause: Option<Box<Fail>>,
 }
 
-impl<D: Display + Debug + Sync + Send + 'static> Fail for ErrorMessage<D> { }
+impl<D: Display + Debug + Sync + Send + 'static> Fail for ErrorMessage<D> {
+	fn cause(&self) -> Option<&Fail> {
+		match self.cause {
+			Some(ref f) => Some(f),
+			None => None
+		}
+	}
+}
 
 impl<D: Display + Debug + Sync + Send + 'static> Display for ErrorMessage<D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ with_std! {
     mod macros;
     mod error_message;
     pub use error_message::err_msg;
+    pub use error_message::err_msg_with;
 }
 
 /// The `Fail` trait.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,6 +16,25 @@ macro_rules! bail {
     };
 }
 
+/// Exits a function early with an `Error` and associated cause `Fail`.
+///
+/// The `bail_with!` macro provides an easy way to exit a function with an
+/// `Error` and associated cause `Fail`. `bail_with!(C, X)` is
+/// equivalent to writing:
+///
+/// ```rust,ignore
+/// return Err(err_msg_with!(C, X))
+/// ```
+#[macro_export]
+macro_rules! bail_with {
+    ($cause:expr, $msg:expr) => {
+        return Err($crate::err_msg_with($cause, $msg));
+    };
+    ($cause:expr, $fmt:expr, $($arg:tt)+) => {
+        return Err($crate::err_msg_with($cause, format!($fmt, $($arg)+)));
+    };
+}
+
 /// Exits a function early with an `Error` if the condition is not satisfied.
 ///
 /// Similar to `assert!`, `ensure!` takes a condition and exits the function


### PR DESCRIPTION
I think this will be useful for creating human-readable error messages when using a function that returns `Fail`.

`do_stuff().or_else(|f| bail_with!(f, "Failed to do stuff"))`

I couldn't think of better names for `err_msg_with` and `bail_with`, so maybe other folks have better ideas.