### PR TITLE
Allow depending on std without depending on backtrace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ cache: cargo
 script:
   - cargo test
   - cargo test --features backtrace
-  - cargo test --no-default-features --features std2,derive
+  - cargo test --no-default-features --features "std2 derive"
   - cargo check --no-default-features
   - cargo check --no-default-features --features std2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ cache: cargo
 script:
   - cargo test
   - cargo test --features backtrace
+  - cargo test --no-default-features --features std2,derive
   - cargo check --no-default-features
+  - cargo check --no-default-features --features std2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,9 @@ members = [".", "failure_derive"]
 [features]
 default = ["std", "derive"]
 #small-error = ["std"]
-std = ["backtrace"]
+std = ["backtrace", "std2"]
+# temporary feature to enable 'std' without enabling 'backtrace' while still keeping backwards
+# compatibility ("std" has always depended on "backtrace" and it would be a breaking change to
+# change that)
+std2 = []
 derive = ["failure_derive"]

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Debug, Display};
 
-macro_rules! with_backtrace { ($($i:item)*) => ($(#[cfg(all(feature = "backtrace", feature = "std"))]$i)*) }
-macro_rules! without_backtrace { ($($i:item)*) => ($(#[cfg(not(all(feature = "backtrace", feature = "std")))]$i)*) }
+macro_rules! with_backtrace { ($($i:item)*) => ($(#[cfg(all(feature = "backtrace", feature = "std2"))]$i)*) }
+macro_rules! without_backtrace { ($($i:item)*) => ($(#[cfg(not(all(feature = "backtrace", feature = "std2")))]$i)*) }
 
 without_backtrace! {
     /// A `Backtrace`.
@@ -43,12 +43,12 @@ without_backtrace! {
             Backtrace { _secret: () }
         }
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "std2")]
         pub(crate) fn none() -> Backtrace {
             Backtrace { _secret: () }
         }
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "std2")]
         pub(crate) fn is_none(&self) -> bool {
             true
         }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -5,14 +5,14 @@ use backtrace::Backtrace;
 use context::Context;
 use compat::Compat;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "std2")]
 use box_std::BoxStd;
 
 #[cfg_attr(feature = "small-error", path = "./error_impl_small.rs")]
 mod error_impl;
 use self::error_impl::ErrorImpl;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "std2")]
 use std::error::Error as StdError;
 
 
@@ -59,7 +59,7 @@ impl Error {
     ///     Ok(92)
     /// }
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "std2")]
     pub fn from_boxed_compat(err: Box<StdError + Sync + Send + 'static>) -> Error {
         Error::from(BoxStd(err))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,13 @@
 //! variable to a non-zero value (this also enables backtraces for panics).
 //! Use the `RUST_FAILURE_BACKTRACE` variable to enable or disable backtraces
 //! for `failure` specifically.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std2"), no_std)]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![cfg_attr(feature = "small-error", feature(extern_types, allocator_api))]
 
-macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }
-macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*) }
+macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std2")]$i)*) }
+macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std2"))]$i)*) }
 
 // Re-export libcore using an alias so that the macros can work without
 // requiring `extern crate core` downstream.
@@ -34,7 +34,7 @@ macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*)
 pub extern crate core as _core;
 
 mod backtrace;
-#[cfg(feature = "std")]
+#[cfg(feature = "std2")]
 mod box_std;
 mod compat;
 mod context;
@@ -251,10 +251,10 @@ impl Fail {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "std2")]
 impl<E: StdError + Send + Sync + 'static> Fail for E {}
 
-#[cfg(feature = "std")]
+#[cfg(feature = "std2")]
 impl Fail for Box<Fail> {
     fn cause(&self) -> Option<&Fail> {
         (**self).cause()

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -14,9 +14,9 @@ pub trait ResultExt<T, E> {
     /// #    tests::run_test();
     /// # }
     /// #
-    /// # #[cfg(not(all(feature = "std", feature = "derive")))] mod tests { pub fn run_test() { } }
-    /// #  
-    /// # #[cfg(all(feature = "std", feature = "derive"))] mod tests {
+    /// # #[cfg(not(all(feature = "std2", feature = "derive")))] mod tests { pub fn run_test() { } }
+    /// #
+    /// # #[cfg(all(feature = "std2", feature = "derive"))] mod tests {
     /// use std::error::Error;
     /// # use std::fmt;
     /// #
@@ -65,19 +65,19 @@ pub trait ResultExt<T, E> {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "std", feature = "derive"))]
+    /// # #[cfg(all(feature = "std2", feature = "derive"))]
     /// # #[macro_use] extern crate failure;
     /// #
-    /// # #[cfg(all(feature = "std", feature = "derive"))]
+    /// # #[cfg(all(feature = "std2", feature = "derive"))]
     /// # #[macro_use] extern crate failure_derive;
     /// #
     /// # fn main() {
     /// #    tests::run_test();
     /// # }
     /// #
-    /// # #[cfg(not(all(feature = "std", feature = "derive")))] mod tests { pub fn run_test() { } }
+    /// # #[cfg(not(all(feature = "std2", feature = "derive")))] mod tests { pub fn run_test() { } }
     /// #
-    /// # #[cfg(all(feature = "std", feature = "derive"))] mod tests {
+    /// # #[cfg(all(feature = "std2", feature = "derive"))] mod tests {
     /// #
     /// # use failure::{self, ResultExt};
     /// #
@@ -108,19 +108,19 @@ pub trait ResultExt<T, E> {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(all(feature = "std", feature = "derive"))]
+    /// # #[cfg(all(feature = "std2", feature = "derive"))]
     /// # #[macro_use] extern crate failure;
     /// #
-    /// # #[cfg(all(feature = "std", feature = "derive"))]
+    /// # #[cfg(all(feature = "std2", feature = "derive"))]
     /// # #[macro_use] extern crate failure_derive;
     /// #
     /// # fn main() {
     /// #    tests::run_test();
     /// # }
     /// #
-    /// # #[cfg(not(all(feature = "std", feature = "derive")))] mod tests { pub fn run_test() { } }
+    /// # #[cfg(not(all(feature = "std2", feature = "derive")))] mod tests { pub fn run_test() { } }
     /// #
-    /// # #[cfg(all(feature = "std", feature = "derive"))] mod tests {
+    /// # #[cfg(all(feature = "std2", feature = "derive"))] mod tests {
     /// #
     /// # use failure::{self, ResultExt};
     /// #

--- a/travis.sh
+++ b/travis.sh
@@ -10,6 +10,7 @@ test_failure_in() {
   cd $1
   cargo_test
   cargo_test --no-default-features
+  cargo_test --features std2,derive
   cargo_test --features backtrace
   test_derive_in "$1/failure_derive"
   cd $DIR


### PR DESCRIPTION
This is done through adding a new `std2` feature which acts exactly like `std`, but without the dependency on `backtrace`.

This is a hack, but it should be an effective one until we can make 'std' itself not depend on backtrace in v0.2.

With this, someone can depend on `failure = { version = "0.1", default-features = false, features = ["std2"] }` to bring in `std` implementations without bringing in the dependency on `backtrace`.

---

I'm undecided as to whether this is a good idea. If failure 0.2.0 is soon to be created, this would be pretty pointless and create churn in the features and in crates depending on `failure` for no reason. If it's another half year away, this could be a good addition for allowing use of `failure` without `backtrace` backwards compatibly.

Fixes #127.