### PR TITLE
Override name in derive

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# Version 0.1.6
+
+- Add `#[fail(name = ...)]` for overriding derived error's name.
+
 # Version 0.1.5
 
 - Resolve a regression with error conversions (#290)

--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -175,3 +175,39 @@ enum MyEnumError {
     Variant2(#[fail(cause)] io::Error),
 }
 ```
+
+## Overriding `name`
+
+By default, `name()` method of derived implementation of `Fail` returns absolute type name:
+```rust
+#[derive(Fail, Debug)]
+struct MyError;
+
+assert_eq!(MyError.name(), Some("crate_name::MyError"));
+```
+
+To specify your own value for error's name use the `#[fail(name = ...)]` attribute:
+```rust
+#[macro_use] extern crate failure;
+
+use std::io;
+
+/// MyError::name will return Some("MY_ERROR") now.
+#[derive(Fail, Debug)]
+#[fail(name = "MY_ERROR")]
+struct MyError {
+    io_error: io::Error,
+}
+
+/// MyEnumError::name will return Some("MY_VARIANT_1") for Variant1
+/// and Some("MY_VARIANT_2") for Variant2,
+/// but None for Variant 3.
+#[derive(Fail, Debug)]
+enum MyEnumError {
+    #[fail(name = "MY_VARIANT_1")]
+    Variant1,
+    #[fail(name = "MY_VARIANT_2")]
+    Variant2(#[fail(cause)] io::Error),
+    Variant3,
+}
+```

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,6 +9,7 @@ struct MyError;
 
 #[derive(Debug, Fail)]
 #[fail(display = "my wrapping error")]
+#[fail(name = "WRAPPING_ERROR")]
 struct WrappingError(#[fail(cause)] MyError);
 
 fn bad_function() -> Result<(), WrappingError> {
@@ -17,6 +18,6 @@ fn bad_function() -> Result<(), WrappingError> {
 
 fn main() {
     for cause in Fail::iter_chain(&bad_function().unwrap_err()) {
-        println!("{}: {}", cause.name().unwrap_or("Error"), cause);
+        println!("{}: {}", cause.name().unwrap(), cause);
     }
 }

--- a/failure_derive/tests/backtrace.rs
+++ b/failure_derive/tests/backtrace.rs
@@ -1,5 +1,4 @@
 extern crate failure;
-#[macro_use]
 extern crate failure_derive;
 
 use failure::{Backtrace, Fail};

--- a/failure_derive/tests/custom_type_bounds.rs
+++ b/failure_derive/tests/custom_type_bounds.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate failure;
 
 use std::fmt::Debug;

--- a/failure_derive/tests/no_derive_display.rs
+++ b/failure_derive/tests/no_derive_display.rs
@@ -1,5 +1,4 @@
 extern crate failure;
-#[macro_use]
 extern crate failure_derive;
 
 use failure::Fail;

--- a/failure_derive/tests/tests.rs
+++ b/failure_derive/tests/tests.rs
@@ -1,27 +1,36 @@
 extern crate failure;
-#[macro_use]
 extern crate failure_derive;
+
+use failure::Fail;
 
 #[derive(Fail, Debug)]
 #[fail(display = "An error has occurred.")]
+#[fail(name = "UNIT_ERROR")]
 struct UnitError;
 
 #[test]
 fn unit_struct() {
     let s = format!("{}", UnitError);
     assert_eq!(&s[..], "An error has occurred.");
+
+    assert_eq!(UnitError.name().unwrap(), "UNIT_ERROR");
 }
 
 #[derive(Fail, Debug)]
 #[fail(display = "Error code: {}", code)]
+#[fail(name = "RECORD_ERROR")]
 struct RecordError {
     code: u32,
 }
 
 #[test]
 fn record_struct() {
-    let s = format!("{}", RecordError { code: 0 });
+    let err = RecordError { code: 0 };
+
+    let s = format!("{}", err);
     assert_eq!(&s[..], "Error code: 0");
+
+    assert_eq!(err.name().unwrap(), "RECORD_ERROR");
 }
 
 #[derive(Fail, Debug)]
@@ -37,19 +46,30 @@ fn tuple_struct() {
 #[derive(Fail, Debug)]
 enum EnumError {
     #[fail(display = "Error code: {}", code)]
+    #[fail(name = "STRUCT")]
     StructVariant { code: i32 },
     #[fail(display = "Error: {}", _0)]
+    #[fail(name = "TUPLE")]
     TupleVariant(&'static str),
     #[fail(display = "An error has occurred.")]
+    #[fail(name = "UNIT")]
     UnitVariant,
 }
 
 #[test]
 fn enum_error() {
-    let s = format!("{}", EnumError::StructVariant { code: 2 });
+    let structure = EnumError::StructVariant { code: 2 };
+    let s = format!("{}", structure);
     assert_eq!(&s[..], "Error code: 2");
-    let s = format!("{}", EnumError::TupleVariant("foobar"));
+    assert_eq!(structure.name().unwrap(), "STRUCT");
+
+    let tuple = EnumError::TupleVariant("foobar");
+    let s = format!("{}", tuple);
     assert_eq!(&s[..], "Error: foobar");
-    let s = format!("{}", EnumError::UnitVariant);
+    assert_eq!(tuple.name().unwrap(), "TUPLE");
+
+    let unit = EnumError::UnitVariant;
+    let s = format!("{}", unit);
     assert_eq!(&s[..], "An error has occurred.");
+    assert_eq!(unit.name().unwrap(), "UNIT");
 }

--- a/failure_derive/tests/tests.rs
+++ b/failure_derive/tests/tests.rs
@@ -52,7 +52,6 @@ enum EnumError {
     #[fail(name = "TUPLE")]
     TupleVariant(&'static str),
     #[fail(display = "An error has occurred.")]
-    #[fail(name = "UNIT")]
     UnitVariant,
 }
 
@@ -71,5 +70,5 @@ fn enum_error() {
     let unit = EnumError::UnitVariant;
     let s = format!("{}", unit);
     assert_eq!(&s[..], "An error has occurred.");
-    assert_eq!(unit.name().unwrap(), "UNIT");
+    assert!(unit.name().is_none());
 }

--- a/failure_derive/tests/wraps.rs
+++ b/failure_derive/tests/wraps.rs
@@ -1,5 +1,4 @@
 extern crate failure;
-#[macro_use]
 extern crate failure_derive;
 
 use std::fmt;
@@ -58,8 +57,11 @@ fn wrap_backtrace_error() {
         .and_then(|err| err.downcast_ref::<io::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
-    assert!(err.backtrace().is_empty());
-    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
+    assert!(err.backtrace().unwrap().is_empty());
+    assert_eq!(
+        err.backtrace().unwrap().is_empty(),
+        err.backtrace().unwrap().to_string().trim().is_empty()
+    );
 }
 
 #[derive(Fail, Debug)]
@@ -93,6 +95,9 @@ fn wrap_enum_error() {
         .and_then(|err| err.downcast_ref::<fmt::Error>())
         .is_some());
     assert!(err.backtrace().is_some());
-    assert!(err.backtrace().is_empty());
-    assert_eq!(err.backtrace().is_empty(), err.backtrace().to_string().trim().is_empty());
+    assert!(err.backtrace().unwrap().is_empty());
+    assert_eq!(
+        err.backtrace().unwrap().is_empty(),
+        err.backtrace().unwrap().to_string().trim().is_empty()
+    );
 }


### PR DESCRIPTION
## Summary

This PR adds additional `#[fail(name = ...)]` attribute into `failure_derive`, which allows to specify custom error's name instead of automatically generated. If no attribute is specified then current behavior is preserved.

## Motivation

It appears to be handy to use `Fail::name()` for custom error codes in the code base of the same application. However, doing so disallows derive usage as we need to implement `Fail` manually. Having ability to override `Fail::name()` result in derive simplifies things a lot.

## Checklist

- [x] Tests are added.
- [x] Documentation is updated.
- [x] Changelog entry is added.