### PR TITLE
Fix book example code (use-error.md)

### DIFF
--- a/book/src/use-error.md
+++ b/book/src/use-error.md
@@ -16,8 +16,8 @@ functions:
 use std::io;
 use std::io::BufRead;
 
+use failure::format_err;
 use failure::Error;
-use failure::err_msg;
 
 fn my_function() -> Result<(), Error> {
     let stdin = io::stdin();


### PR DESCRIPTION
`error_msg` is not used in this example, and `format_err` is not imported.