### PR TITLE
Deprecate failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ homepage = "https://rust-lang-nursery.github.io/failure/"
 license = "MIT OR Apache-2.0"
 name = "failure"
 repository = "https://github.com/rust-lang-nursery/failure"
-version = "0.1.7"
 
+version = "0.1.8"
 [dependencies.failure_derive]
 optional = true
 version = "0.1.7"
@@ -19,6 +19,9 @@ version = "0.3.3"
 
 [workspace]
 members = [".", "failure_derive"]
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [features]
 default = ["std", "derive"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # failure - a new error management story
 
+**Notice**: `failure` is deprecated. If you liked `failure`'s API, consider using:
+- [Anyhow](https://github.com/dtolnay/anyhow) is a good replacement for `failure::Error`.
+- [thiserror](https://github.com/dtolnay/thiserror) is a good, near drop-in replacement for `#[derive(Fail)]`.
+
+---
+
 [![Build Status](https://travis-ci.org/rust-lang-nursery/failure.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/failure)
 [![Latest Version](https://img.shields.io/crates/v/failure.svg)](https://crates.io/crates/failure)
 [![docs](https://docs.rs/failure/badge.svg)](https://docs.rs/failure)

--- a/failure_derive/Cargo.toml
+++ b/failure_derive/Cargo.toml
@@ -6,7 +6,7 @@ name = "failure_derive"
 repository = "https://github.com/rust-lang-nursery/failure"
 homepage = "https://rust-lang-nursery.github.io/failure/"
 documentation = "https://docs.rs/failure"
-version = "0.1.7"
+version = "0.1.8"
 build = "build.rs"
 
 [dependencies]
@@ -18,6 +18,9 @@ proc-macro2 = "1"
 [dev-dependencies.failure]
 version = "0.1.0"
 path = ".."
+
+[badges]
+maintenance = { status = "deprecated" }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
As per https://internals.rust-lang.org/t/failure-crate-maintenance/12087, I'm deprecating `failure`. Since the current error-handling landscape in Rust wouldn't be what it is today without `failure`, I'd like to thank @withoutboats for authoring and publishing this crate.